### PR TITLE
fix for a minted "missing pygments output" error

### DIFF
--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -31,7 +31,7 @@ if get(g:, 'neotex_latexdiff', 0)
 	let b:neotex_jobexe .= fnameescape(expand('%:t')) . ' ' . s:neotex_buffer_tempname . ' > ' . s:neotex_preview_tempname . ' && '
 endif
 
-let b:neotex_jobexe .= 'pdflatex -jobname=' . fnameescape(expand('%:t:r')) . ' -interaction=nonstopmode '
+let b:neotex_jobexe .= 'pdflatex -shell-escape -jobname=' . fnameescape(expand('%:t:r')) . ' -interaction=nonstopmode '
 if exists('neotex_pdflatex_add_options')
 	let b:neotex_jobexe .= g:neotex_pdflatex_add_options . ' '
 endif


### PR DESCRIPTION
I use `minted` package to highlight code snippets in my `latex` documents. I encountered a weird error when `minted` can't locate pigments output for a file that definitely exists in the same directory and should be included in a resulting document. 

It turns out that minted requires `pdflatex` to be executed with `-shell-escape` option in order to compile the document together with generated by `minted` code snippet. 

Additional reference: https://github.com/gpoore/minted/issues/81

My fix is an obvious one and seems to cause no side effects.  